### PR TITLE
Create cmake.yml for supporting actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,19 @@
+name: CMake
+
+on: [push]
+
+env:
+  # 2021, Shishkov M.: Currently only this build type is hardcoded in the build.sh file
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      working-directory: ${{github.workspace}}
+      shell: bash
+      run: build.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         execute_process(COMMAND chmod +x ninja)
         execute_process(COMMAND ./ninja --version)
-        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
+        # file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
         execute_process(
             COMMAND cmake
               -S .

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,8 @@ jobs:
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         message( STATUS "Current folder: ${CMAKE_CURRENT_SOURCE_DIR}" )
         execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}:$PATH)
+        execute_process(COMMAND cp -l ./PCA9685servo)
+        execute_process(COMMAND cp -l ./TSL2581)
         execute_process(COMMAND chmod +x ninja)
         execute_process(COMMAND ./ninja --version)
         execute_process(COMMAND ls -R)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,6 +23,7 @@ jobs:
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         execute_process(COMMAND chmod +x ninja)
+        message( STATUS "Current folder: $pwd" )
         execute_process(COMMAND export PATH=$pwd:$PATH)
         execute_process(COMMAND ls -R)
         

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,6 +23,7 @@ jobs:
         set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
+        COMMAND chmod +x ninja
       
     - name: Build
       working-directory: ${{env.WORKING-DIR}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: bash ./build.sh ninja
+      run: bash ./build.sh $(pwd)/ninja
       
     - name: PostBuild
       working-directory: ${CMAKE_CURRENT_SOURCE_DIR}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,7 +25,7 @@ jobs:
         message( STATUS "Current folder: ${CMAKE_CURRENT_SOURCE_DIR}" )
         execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}:$PATH)
         execute_process(COMMAND chmod +x ninja)
-        ./ninja --version
+        execute_process(COMMAND ./ninja --version)
         execute_process(COMMAND ls -R)
         
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,7 +51,7 @@ jobs:
         execute_process(COMMAND ls -R)
         execute_process(
           COMMAND chmod +x PCA9685servo
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/PCA9685servo
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/Release/PCA9685servo
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,7 +3,7 @@ name: CMake
 on: [push]
 
 env:
-  # 2021, Shishkov M.: Currently only this build type is hardcoded in the build.sh file
+  # 2021, Shishkov M.: Currently with only release build type hardcoded in the build.sh file
   BUILD_TYPE: Release
   WORKING-DIR: .
 
@@ -13,7 +13,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+    
+    - name: Prepare
+      working-directory: ${{env.WORKING-DIR}}
+      shell: cmake -P {0}
+      run: |
+        set(ninja_version "1.9.0")
+        set(ninja_suffix "linux.zip")
+        set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
+        file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
+      
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,8 @@ jobs:
         set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
-        COMMAND chmod +x ninja
+        execute_process(COMMAND chmod +x ninja)
+        execute_process(COMMAND ls -R)
       
     - name: Build
       working-directory: ${{env.WORKING-DIR}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,7 @@ on: [push]
 env:
   # 2021, Shishkov M.: Currently only this build type is hardcoded in the build.sh file
   BUILD_TYPE: Release
+  WORKING-DIR: .
 
 jobs:
   build:
@@ -14,6 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build
-      working-directory: ${{github.workspace}}
+      working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: build.sh
+      run: |
+          ls -R | build.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,7 +45,7 @@ jobs:
       run: bash ./build.sh $(pwd)/ninja
       
     - name: PostBuild
-      working-directory: ${CMAKE_CURRENT_SOURCE_DIR}
+      working-directory: ${{env.WORKING-DIR}}
       shell: cmake -P {0}
       run: |
         execute_process(COMMAND ls -R)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: bash ./build.sh ./ninja
+      run: bash ./build.sh ninja
       
     - name: PostBuild
       working-directory: ${CMAKE_CURRENT_SOURCE_DIR}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,7 +41,9 @@ jobs:
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: bash ./build.sh
+      run: |
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
+        bash ./build.sh
       
     - name: PostBuild
       working-directory: ${CMAKE_CURRENT_SOURCE_DIR}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,9 +22,9 @@ jobs:
         set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
-        execute_process(COMMAND chmod +x ninja)
         message( STATUS "Current folder: ${CMAKE_CURRENT_SOURCE_DIR}" )
-        execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}:$PATH)
+        execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}/ninja:$PATH)
+        execute_process(COMMAND chmod +x ninja)
         execute_process(COMMAND ls -R)
         
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,9 +24,9 @@ jobs:
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         message( STATUS "Current folder: ${CMAKE_CURRENT_SOURCE_DIR}" )
         execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}:$PATH)
-        execute_process(COMMAND cp -l ./PCA9685servo)
-        execute_process(COMMAND cp -l ./TSL2581)
         execute_process(COMMAND chmod +x ninja)
+        execute_process(COMMAND cp -l ninja ./PCA9685servo)
+        execute_process(COMMAND cp -l ninja ./TSL2581)
         execute_process(COMMAND ./ninja --version)
         execute_process(COMMAND ls -R)
         
@@ -36,7 +36,17 @@ jobs:
       run: bash ./build.sh
       
     - name: PostBuild
-      working-directory: ${{env.WORKING-DIR}}
+      working-directory: ${CMAKE_CURRENT_SOURCE_DIR}
       shell: cmake -P {0}
-      run: execute_process(COMMAND ls -R)
+      run: |
+        execute_process(COMMAND ls -R)
+        execute_process(
+          COMMAND chmod +x PCA9685servo
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/Release/PCA9685servo
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Running tests failed!")
+        endif()
+      
       

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,9 +10,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2   
     
     - name: Prepare
       working-directory: ${{env.WORKING-DIR}}
@@ -24,9 +23,16 @@ jobs:
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         execute_process(COMMAND chmod +x ninja)
+        execute_process(COMMAND export PATH=$pwd:$PATH)
         execute_process(COMMAND ls -R)
-      
+        
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: ls -R | bash ./build.sh
+      run: bash ./build.sh
+      
+    - name: PostBuild
+      working-directory: ${{env.WORKING-DIR}}
+      shell: cmake -P {0}
+      run: execute_process(COMMAND ls -R)
+      

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: ls -R | ./build.sh
+      run: ls -R | bash ./build.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: bash ./build.sh $ENV{GITHUB_WORKSPACE}/ninja
+      run: bash ./build.sh ./ninja
       
     - name: PostBuild
       working-directory: ${CMAKE_CURRENT_SOURCE_DIR}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,13 +22,23 @@ jobs:
         set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
-        message( STATUS "Current folder: ${CMAKE_CURRENT_SOURCE_DIR}" )
-        execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}:$PATH)
         execute_process(COMMAND chmod +x ninja)
-        execute_process(COMMAND cp -l ninja ./PCA9685servo)
-        execute_process(COMMAND cp -l ninja ./TSL2581)
         execute_process(COMMAND ./ninja --version)
-        execute_process(COMMAND ls -R)
+        set(ENV{CC} ${ { matrix.config.cc } })
+        set(ENV{CXX} ${ { matrix.config.cxx } })
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
+        execute_process(
+            COMMAND ${ cmake
+              -S .
+              -B build
+              -D CMAKE_BUILD_TYPE=${ { env.BUILD_TYPE } }
+              -G Ninja
+              -D CMAKE_MAKE_PROGRAM=${ninja_program}
+            RESULT_VARIABLE result
+          )
+          if (NOT result EQUAL 0)
+            message(FATAL_ERROR "Bad exit status")
+          endif()
         
     - name: Build
       working-directory: ${{env.WORKING-DIR}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,7 +29,7 @@ jobs:
             COMMAND cmake
               -S .
               -B build
-              -D CMAKE_BUILD_TYPE=${ { env.BUILD_TYPE } }
+              -D CMAKE_BUILD_TYPE=${env.BUILD_TYPE}
               -G Ninja
               -D CMAKE_MAKE_PROGRAM=${ninja_program}
             RESULT_VARIABLE result

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,8 @@ jobs:
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         execute_process(COMMAND chmod +x ninja)
         execute_process(COMMAND ./ninja --version)
-        # file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
+        # ensures finding the corresponding ninja generator
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
         execute_process(
             COMMAND cmake
               -S .
@@ -41,9 +42,7 @@ jobs:
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: |
-        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
-        bash ./build.sh
+      run: bash ./build.sh $ENV{GITHUB_WORKSPACE}/ninja
       
     - name: PostBuild
       working-directory: ${CMAKE_CURRENT_SOURCE_DIR}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,7 +51,7 @@ jobs:
         execute_process(COMMAND ls -R)
         execute_process(
           COMMAND chmod +x PCA9685servo
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/Release/PCA9685servo
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/PCA9685servo
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,11 +24,9 @@ jobs:
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         execute_process(COMMAND chmod +x ninja)
         execute_process(COMMAND ./ninja --version)
-        set(ENV{CC} ${ { matrix.config.cc } })
-        set(ENV{CXX} ${ { matrix.config.cxx } })
         file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
         execute_process(
-            COMMAND ${ cmake
+            COMMAND cmake
               -S .
               -B build
               -D CMAKE_BUILD_TYPE=${ { env.BUILD_TYPE } }

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,8 +23,9 @@ jobs:
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         message( STATUS "Current folder: ${CMAKE_CURRENT_SOURCE_DIR}" )
-        execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}/ninja:$PATH)
+        execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}:$PATH)
         execute_process(COMMAND chmod +x ninja)
+        ./ninja --version
         execute_process(COMMAND ls -R)
         
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,8 +23,8 @@ jobs:
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
         execute_process(COMMAND chmod +x ninja)
-        message( STATUS "Current folder: $pwd" )
-        execute_process(COMMAND export PATH=$pwd:$PATH)
+        message( STATUS "Current folder: ${CMAKE_CURRENT_SOURCE_DIR}" )
+        execute_process(COMMAND export PATH=${CMAKE_CURRENT_SOURCE_DIR}:$PATH)
         execute_process(COMMAND ls -R)
         
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,5 +17,4 @@ jobs:
     - name: Build
       working-directory: ${{env.WORKING-DIR}}
       shell: bash
-      run: |
-          ls -R | build.sh
+      run: ls -R | ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -24,8 +24,10 @@ echo "Gulliversoft 2021, Copyright M. Shishkov manage with:" $toolchain
 
 if [ "$#" = "1" ]; then
         ninja_program="$1"
+        ninja_relative= ../../$ninja_program
 else
         ninja_program="ninja"
+        ninja_relative=$ninja_program
 fi 
 
 echo "CMake generator used:" $ninja_program
@@ -44,7 +46,7 @@ popd
 
 pushd ./build/Release
 
-$ninja_program
+$ninja_relative
 
 popd 
 

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ x86_64) toolchain="/../_toolchains/lin_4_lin.cmake";;
 esac
 
 echo "Gulliversoft 2021, Copyright M. Shishkov manage with:" $toolchain
+echo "CMake generator used:" ${ninja_program}
 
 pushd ./build
 echo "Build Product(s): am65x"

--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ esac
 echo "Gulliversoft 2021, Copyright M. Shishkov manage with:" $toolchain
 
 if [ "$#" = "1" ]; then
-        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
+        ninja_program="$1"
 else
         ninja_program="ninja"
 fi 

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ cmake \
 -G Ninja \
 -DPROJECT_ROOT:PATH=$(pwd)/.. \
 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=$(pwd)$toolchain \
--DCMAKE_MAKE_PROGRAM:FILEPATH=ninja \
+-DCMAKE_MAKE_PROGRAM:FILEPATH=${ninja_program} \
 -DCMAKE_BUILD_TYPE:STRING=Release \
 ..
 popd 

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,14 @@ x86_64) toolchain="/../_toolchains/lin_4_lin.cmake";;
 esac
 
 echo "Gulliversoft 2021, Copyright M. Shishkov manage with:" $toolchain
-echo "CMake generator used:" ${ninja_program}
+
+if [ "$#" = "1" ]; then
+        ninja_program="$1"
+else
+        ninja_program="ninja"
+fi 
+
+echo "CMake generator used:" $1
 
 pushd ./build
 echo "Build Product(s): am65x"
@@ -30,7 +37,7 @@ cmake \
 -G Ninja \
 -DPROJECT_ROOT:PATH=$(pwd)/.. \
 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=$(pwd)$toolchain \
--DCMAKE_MAKE_PROGRAM:FILEPATH=${ninja_program} \
+-DCMAKE_MAKE_PROGRAM:FILEPATH=$ninja_program \
 -DCMAKE_BUILD_TYPE:STRING=Release \
 ..
 popd 

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ popd
 
 pushd ./build/Release
 
-ninja
+$ninja_program
 
 popd 
 

--- a/build.sh
+++ b/build.sh
@@ -23,12 +23,12 @@ esac
 echo "Gulliversoft 2021, Copyright M. Shishkov manage with:" $toolchain
 
 if [ "$#" = "1" ]; then
-        ninja_program="$1"
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
 else
         ninja_program="ninja"
 fi 
 
-echo "CMake generator used:" $1
+echo "CMake generator used:" $ninja_program
 
 pushd ./build
 echo "Build Product(s): am65x"

--- a/build.sh
+++ b/build.sh
@@ -24,10 +24,8 @@ echo "Gulliversoft 2021, Copyright M. Shishkov manage with:" $toolchain
 
 if [ "$#" = "1" ]; then
         ninja_program="$1"
-        ninja_relative= ../../$ninja_program
 else
         ninja_program="ninja"
-        ninja_relative=$ninja_program
 fi 
 
 echo "CMake generator used:" $ninja_program
@@ -46,7 +44,7 @@ popd
 
 pushd ./build/Release
 
-$ninja_relative
+$ninja_program
 
 popd 
 


### PR DESCRIPTION
The CMake action should just execute the build.sh, instead of generating new folders and CMakeList files.